### PR TITLE
Remove reference to specific gender ratios

### DIFF
--- a/facilitator_tips_&_tricks.md
+++ b/facilitator_tips_&_tricks.md
@@ -13,7 +13,7 @@ The success of any event lies with the facilitator — it’s all in your hands!
 3. Define clear objectives-- concrete things you want to accomplish, that you could test at the end of the session-- these will help you select your materials and activities. Examples: Know how to make a pull request in GitHub, defend against challenges to Open Science. 
 4. Don’t overload your session; give participants enough time to process materials/activities.
 5. If possible, send out an agenda so participants know what to expect.
-6. Aim to get a good gender balance in the room so everyone feels comfortable speaking. One male for every two females is a good guideline.
+6. Aim to get a good gender balance in the room so everyone feels comfortable speaking. 
 7. Build in some free time (breaks) for participants to talk and connect with each other
 
 ###On-site, before the event


### PR DESCRIPTION
1. When referring to people it’s preferable to speak about men and women. “Males” and “females” can equally refer to animals, so it’s more respectable to use human-specific language.
2. The previous phrasing wasn’t particularly inclusive for people outside of the gender binary.
3. It’s unclear where the 2:1 ratio comes from. Unless there is some clear evidence for it I think the first sentence of the rule is helpful enough.